### PR TITLE
Cambios de variables de ambiente

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -64,6 +64,17 @@ quarkus.openshift.expose=false
 # Número de contenedores por defecto
 quarkus.openshift.replicas=1
 
+# Configuración de JAVA, quita las opciones -Xmx
+quarkus.openshift.env.vars.java-max-mem-ratio=0
+
+# Configuración de la zona horaria
+quarkus.openshift.env.vars.tz=America/Mexico_City
+
+quarkus.openshift.jvm-arguments=-Dquarkus.http.host=0.0.0.0,-Djava.util.logging.manager=org.jboss.logmanager.LogManager,-XX:+UseContainerSupport,-XX:MaxRAMPercentage=80
+quarkus.s2i.jvm-arguments=-Dquarkus.http.host=0.0.0.0,-Djava.util.logging.manager=org.jboss.logmanager.LogManager,-XX:+UseContainerSupport,-XX:MaxRAMPercentage=80
+
+# desactiva Jolokia para JAVA 11
+quarkus.openshift.env.vars.ab-jolokia-off=true
 
 # Propiedades para la prueba de "readiness"
 quarkus.openshift.readiness-probe.initial-delay=20s


### PR DESCRIPTION
Se cierra el problema con jolokia (no soportada en java 11) y se agregan ademas variables de ambiente para mejorar el contexto del pod.

Closes #4 